### PR TITLE
Feature/update rules

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,17 @@
+# https://dependabot.com/docs/config-file/
+
+version: 1
+
+update_configs:
+  - automerged_updates:
+      - match:
+          dependency_type: "development"
+    commit_message:
+      include_scope: true
+      prefix: "Build"
+    default_labels:
+      - "dependency"
+    directory: "/"
+    package_manager: "php:composer"
+    update_schedule: "live"
+    version_requirement_updates: "increase_versions"

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@ build              export-ignore
 phpstan.neon       export-ignore
 
 phpunit.xml.dist               export-ignore
-phpunit.php                    export-ignore
 
 CONTRIBUTING.md                export-ignore
 README.md                      export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ install:
   - $COMPOSER_UP
 
 jobs:
-  allow_failures:
-    - php: nightly
-    - php: 7.4snapshot
-
   include:
     - stage: Test
       php: 7.2
@@ -33,11 +29,8 @@ jobs:
       php: 7.3
       env: REMOVE_XDEBUG=true
     - stage: Test
-      php: 7.4snapshot
-#      env: REMOVE_XDEBUG=true
-    - stage: Test
-      php: nightly
-#      env: REMOVE_XDEBUG=true
+      php: 7.4
+      env: REMOVE_XDEBUG=true
 
     - stage: Static Analysis
       if: type != cron

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
     ],
     "require": {
         "php": "^7.2",
-        "friendsofphp/php-cs-fixer": "~2.16.0",
-        "kubawerlos/php-cs-fixer-custom-fixers": "~1.16.1",
+        "friendsofphp/php-cs-fixer": "~2.16.1",
+        "kubawerlos/php-cs-fixer-custom-fixers": "~1.17.0",
         "pedrotroller/php-cs-custom-fixer": "~2.19.1"
     },
     "require-dev": {
-        "narrowspark/testing-helper": "^8.0.1",
-        "phpstan/phpstan": "^0.11.16",
-        "phpstan/phpstan-deprecation-rules": "^0.11.2",
-        "phpstan/phpstan-phpunit": "^0.11.2",
-        "phpstan/phpstan-strict-rules": "^0.11.1",
-        "phpunit/phpunit": "^8.4.1",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
+        "narrowspark/testing-helper": "^8.0.2",
+        "phpstan/phpstan": "^0.12.3",
+        "phpstan/phpstan-deprecation-rules": "^0.12.0",
+        "phpstan/phpstan-phpunit": "^0.12.1",
+        "phpstan/phpstan-strict-rules": "^0.12.0",
+        "phpunit/phpunit": "^8.5.2",
+        "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },
     "config": {
         "sort-packages": true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,14 +1,15 @@
 includes:
-    - %rootDir%/../phpstan-deprecation-rules/rules.neon
-    - %rootDir%/../phpstan-phpunit/extension.neon
-    - %rootDir%/../phpstan-phpunit/rules.neon
-    - %rootDir%/../phpstan-strict-rules/rules.neon
-    - %rootDir%/../../thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
-    - %rootDir%/../phpstan/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
 
 parameters:
     level: max
     inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: true
 
     autoload_directories:
         - %currentWorkingDirectory%/src

--- a/src/Config.php
+++ b/src/Config.php
@@ -44,7 +44,7 @@ final class Config extends CsConfig
     /**
      * A list of override rules.
      *
-     * @var array<string, bool|string|array<string, mixed>>
+     * @var array<string, array<string, mixed>|bool|string>
      */
     private $overwriteRules;
 
@@ -55,7 +55,7 @@ final class Config extends CsConfig
      * Create new Config instance.
      *
      * @param null|string                                     $header
-     * @param array<string, bool|string|array<string, mixed>> $overwriteConfig
+     * @param array<string, array<string, mixed>|bool|string> $overwriteConfig
      */
     public function __construct(?string $header = null, array $overwriteConfig = [])
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,6 +8,7 @@ use PhpCsFixer\Config as CsConfig;
 use PhpCsFixerCustomFixers\Fixer\CommentSurroundedBySpacesFixer;
 use PhpCsFixerCustomFixers\Fixer\DataProviderNameFixer;
 use PhpCsFixerCustomFixers\Fixer\DataProviderReturnTypeFixer;
+use PhpCsFixerCustomFixers\Fixer\DataProviderStaticFixer;
 use PhpCsFixerCustomFixers\Fixer\InternalClassCasingFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer;
 use PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer;
@@ -18,11 +19,10 @@ use PhpCsFixerCustomFixers\Fixer\NoLeadingSlashInGlobalNamespaceFixer;
 use PhpCsFixerCustomFixers\Fixer\NoNullableBooleanTypeFixer;
 use PhpCsFixerCustomFixers\Fixer\NoPhpStormGeneratedCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoReferenceInFunctionDefinitionFixer;
-use PhpCsFixerCustomFixers\Fixer\NoUnneededConcatenationFixer;
+use PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessSprintfFixer;
-use PhpCsFixerCustomFixers\Fixer\NullableParamStyleFixer;
 use PhpCsFixerCustomFixers\Fixer\OperatorLinebreakFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocNoSuperfluousParamFixer;
@@ -30,8 +30,8 @@ use PhpCsFixerCustomFixers\Fixer\PhpdocParamOrderFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocParamTypeFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocSelfAccessorFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocSingleLineVarFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocTypesTrimFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpUnitNoUselessReturnFixer;
-use PhpCsFixerCustomFixers\Fixer\SingleLineThrowFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceBeforeStatementFixer;
 use const PHP_VERSION_ID;
@@ -44,18 +44,18 @@ final class Config extends CsConfig
     /**
      * A list of override rules.
      *
-     * @var array
+     * @var array<string, bool|string|array<string, mixed>>
      */
     private $overwriteRules;
 
-    /** @var array */
+    /** @var array<string, array<string, string>> */
     private $headerRules = [];
 
     /**
      * Create new Config instance.
      *
-     * @param null|string $header
-     * @param array       $overwriteConfig
+     * @param null|string                                     $header
+     * @param array<string, bool|string|array<string, mixed>> $overwriteConfig
      */
     public function __construct(?string $header = null, array $overwriteConfig = [])
     {
@@ -133,10 +133,9 @@ final class Config extends CsConfig
             NoNullableBooleanTypeFixer::name() => false,
             NoPhpStormGeneratedCommentFixer::name() => true,
             NoReferenceInFunctionDefinitionFixer::name() => false,
-            NoUnneededConcatenationFixer::name() => true,
+            NoSuperfluousConcatenationFixer::name() => true,
             NoUselessCommentFixer::name() => false,
             NoUselessDoctrineRepositoryCommentFixer::name() => true,
-            NullableParamStyleFixer::name() => false,
             OperatorLinebreakFixer::name() => true,
             PhpdocNoIncorrectVarAnnotationFixer::name() => true,
             PhpdocNoSuperfluousParamFixer::name() => true,
@@ -149,10 +148,11 @@ final class Config extends CsConfig
             DataProviderNameFixer::name() => true,
             NoUselessSprintfFixer::name() => true,
             PhpUnitNoUselessReturnFixer::name() => true,
-            SingleLineThrowFixer::name() => false,
             NoDuplicatedImportsFixer::name() => true,
             DataProviderReturnTypeFixer::name() => true,
             CommentSurroundedBySpacesFixer::name() => true,
+            DataProviderStaticFixer::name() => true,
+            PhpdocTypesTrimFixer::name() => true,
         ];
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Narrowspark\CS\Config\Tests;
 
-use Generator;
 use Narrowspark\CS\Config\Config;
 use Narrowspark\TestingHelper\Traits\AssertArrayTrait;
 use PhpCsFixer\ConfigInterface;
@@ -14,6 +13,7 @@ use PhpCsFixer\RuleSet;
 use PhpCsFixerCustomFixers\Fixer\CommentSurroundedBySpacesFixer;
 use PhpCsFixerCustomFixers\Fixer\DataProviderNameFixer;
 use PhpCsFixerCustomFixers\Fixer\DataProviderReturnTypeFixer;
+use PhpCsFixerCustomFixers\Fixer\DataProviderStaticFixer;
 use PhpCsFixerCustomFixers\Fixer\InternalClassCasingFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilineCommentOpeningClosingAloneFixer;
 use PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer;
@@ -24,11 +24,10 @@ use PhpCsFixerCustomFixers\Fixer\NoLeadingSlashInGlobalNamespaceFixer;
 use PhpCsFixerCustomFixers\Fixer\NoNullableBooleanTypeFixer;
 use PhpCsFixerCustomFixers\Fixer\NoPhpStormGeneratedCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoReferenceInFunctionDefinitionFixer;
-use PhpCsFixerCustomFixers\Fixer\NoUnneededConcatenationFixer;
+use PhpCsFixerCustomFixers\Fixer\NoSuperfluousConcatenationFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessDoctrineRepositoryCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessSprintfFixer;
-use PhpCsFixerCustomFixers\Fixer\NullableParamStyleFixer;
 use PhpCsFixerCustomFixers\Fixer\OperatorLinebreakFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocNoSuperfluousParamFixer;
@@ -36,8 +35,8 @@ use PhpCsFixerCustomFixers\Fixer\PhpdocParamOrderFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocParamTypeFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocSelfAccessorFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocSingleLineVarFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocTypesTrimFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpUnitNoUselessReturnFixer;
-use PhpCsFixerCustomFixers\Fixer\SingleLineThrowFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceBeforeStatementFixer;
 use PHPUnit\Framework\TestCase;
@@ -221,7 +220,7 @@ final class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function provideDoesNotHaveRulesEnabledCases(): iterable
+    public static function provideDoesNotHaveRulesEnabledCases(): iterable
     {
         $symfonyFixers = [
             'self_accessor' => 'it causes an edge case error',
@@ -285,9 +284,9 @@ final class ConfigTest extends TestCase
     }
 
     /**
-     * @return Generator
+     * @return iterable
      */
-    public function provideHeaderCommentFixerIsEnabledIfHeaderIsProvidedCases(): iterable
+    public static function provideHeaderCommentFixerIsEnabledIfHeaderIsProvidedCases(): iterable
     {
         $values = [
             'string-empty' => '',
@@ -371,10 +370,9 @@ final class ConfigTest extends TestCase
             NoNullableBooleanTypeFixer::name() => false,
             NoPhpStormGeneratedCommentFixer::name() => true,
             NoReferenceInFunctionDefinitionFixer::name() => false,
-            NoUnneededConcatenationFixer::name() => true,
+            NoSuperfluousConcatenationFixer::name() => true,
             NoUselessCommentFixer::name() => false,
             NoUselessDoctrineRepositoryCommentFixer::name() => true,
-            NullableParamStyleFixer::name() => false,
             OperatorLinebreakFixer::name() => true,
             PhpdocNoIncorrectVarAnnotationFixer::name() => true,
             PhpdocNoSuperfluousParamFixer::name() => true,
@@ -387,10 +385,11 @@ final class ConfigTest extends TestCase
             DataProviderNameFixer::name() => true,
             NoUselessSprintfFixer::name() => true,
             PhpUnitNoUselessReturnFixer::name() => true,
-            SingleLineThrowFixer::name() => true,
             NoDuplicatedImportsFixer::name() => true,
             DataProviderReturnTypeFixer::name() => true,
             CommentSurroundedBySpacesFixer::name() => true,
+            DataProviderStaticFixer::name() => true,
+            PhpdocTypesTrimFixer::name() => true,
         ];
     }
 


### PR DESCRIPTION
feat : updated kubawerlos/php-cs-fixer-custom-fixers to ~1.17.0
feat : updated friendsofphp/php-cs-fixer to ~2.16.1
fix : removed or replaced deprecated rules from kubawerlos/php-cs-fixer-custom-fixers
feat : enabled DataProviderStaticFixer
feat : enabled PhpdocTypesTrimFixer